### PR TITLE
Create .profile if it does not exist

### DIFF
--- a/tasks/user_and_dirs.yml
+++ b/tasks/user_and_dirs.yml
@@ -18,6 +18,7 @@
     dest: "{{ dehydrated_userhome }}/.profile"
     regexp: "^#?umask"
     line: "umask 0077 # paranoid umask, we're creating private keys "
+    create: yes
 
 
 - name: Create configuration directory {{ dehydrated_configdir }}


### PR DESCRIPTION
Hi,

When running this role on a fresh CentOS 7 system, it errored at the "add umask" step because `.profile` did not exist. This PR fixes this.

Cheers,

Pieter