### PR TITLE
Update the hook template

### DIFF
--- a/templates/hook.sh.j2
+++ b/templates/hook.sh.j2
@@ -1,29 +1,169 @@
 #!/usr/bin/env bash
-set -o nounset -o errexit -o pipefail
 
-function deploy_challenge {
-	:
+deploy_challenge() {
+    local DOMAIN="${1}" TOKEN_FILENAME="${2}" TOKEN_VALUE="${3}"
+
+    # This hook is called once for every domain that needs to be
+    # validated, including any alternative names you may have listed.
+    #
+    # Parameters:
+    # - DOMAIN
+    #   The domain name (CN or subject alternative name) being
+    #   validated.
+    # - TOKEN_FILENAME
+    #   The name of the file containing the token to be served for HTTP
+    #   validation. Should be served by your web server as
+    #   /.well-known/acme-challenge/${TOKEN_FILENAME}.
+    # - TOKEN_VALUE
+    #   The token value that needs to be served for validation. For DNS
+    #   validation, this is what you want to put in the _acme-challenge
+    #   TXT record. For HTTP validation it is the value that is expected
+    #   be found in the $TOKEN_FILENAME file.
+
+    # Simple example: Use nsupdate with local named
+    # printf 'server 127.0.0.1\nupdate add _acme-challenge.%s 300 IN TXT "%s"\nsend\n' "${DOMAIN}" "${TOKEN_VALUE}" | nsupdate -k /var/run/named/session.key
 }
 
-function clean_challenge {
-	:
+clean_challenge() {
+    local DOMAIN="${1}" TOKEN_FILENAME="${2}" TOKEN_VALUE="${3}"
+
+    # This hook is called after attempting to validate each domain,
+    # whether or not validation was successful. Here you can delete
+    # files or DNS records that are no longer needed.
+    #
+    # The parameters are the same as for deploy_challenge.
+
+    # Simple example: Use nsupdate with local named
+    # printf 'server 127.0.0.1\nupdate delete _acme-challenge.%s TXT "%s"\nsend\n' "${DOMAIN}" "${TOKEN_VALUE}" | nsupdate -k /var/run/named/session.key
 }
 
-function unchanged_cert {
-	:
-}
+deploy_cert() {
+    local DOMAIN="${1}" KEYFILE="${2}" CERTFILE="${3}" FULLCHAINFILE="${4}" CHAINFILE="${5}" TIMESTAMP="${6}"
 
-function invalid_challenge {
-	:
-}
+    # This hook is called once for each certificate that has been
+    # produced. Here you might, for instance, copy your new certificates
+    # to service-specific locations and reload the service.
+    #
+    # Parameters:
+    # - DOMAIN
+    #   The primary domain name, i.e. the certificate common
+    #   name (CN).
+    # - KEYFILE
+    #   The path of the file containing the private key.
+    # - CERTFILE
+    #   The path of the file containing the signed certificate.
+    # - FULLCHAINFILE
+    #   The path of the file containing the full certificate chain.
+    # - CHAINFILE
+    #   The path of the file containing the intermediate certificate(s).
+    # - TIMESTAMP
+    #   Timestamp when the specified certificate was created.
 
-function exit_hook {
-	:
-}
-
-function deploy_cert {
-	echo "Hook for domain $1 triggerd, add to {{ dehydrated_configdir }}/to_deploy folder!"
+    # Simple example: Copy file to nginx config
+    # cp "${KEYFILE}" "${FULLCHAINFILE}" /etc/nginx/ssl/; chown -R nginx: /etc/nginx/ssl
+    # systemctl reload nginx
+    
+    echo "Hook for domain $1 triggerd, add to {{ dehydrated_configdir }}/to_deploy folder!"
 	echo "$@" > "{{ dehydrated_configdir }}/to_deploy/$1"
 }
 
-HANDLER=$1; shift; $HANDLER $@
+unchanged_cert() {
+    local DOMAIN="${1}" KEYFILE="${2}" CERTFILE="${3}" FULLCHAINFILE="${4}" CHAINFILE="${5}"
+
+    # This hook is called once for each certificate that is still
+    # valid and therefore wasn't reissued.
+    #
+    # Parameters:
+    # - DOMAIN
+    #   The primary domain name, i.e. the certificate common
+    #   name (CN).
+    # - KEYFILE
+    #   The path of the file containing the private key.
+    # - CERTFILE
+    #   The path of the file containing the signed certificate.
+    # - FULLCHAINFILE
+    #   The path of the file containing the full certificate chain.
+    # - CHAINFILE
+    #   The path of the file containing the intermediate certificate(s).
+}
+
+invalid_challenge() {
+    local DOMAIN="${1}" RESPONSE="${2}"
+
+    # This hook is called if the challenge response has failed, so domain
+    # owners can be aware and act accordingly.
+    #
+    # Parameters:
+    # - DOMAIN
+    #   The primary domain name, i.e. the certificate common
+    #   name (CN).
+    # - RESPONSE
+    #   The response that the verification server returned
+
+    # Simple example: Send mail to root
+    # printf "Subject: Validation of ${DOMAIN} failed!\n\nOh noez!" | sendmail root
+}
+
+request_failure() {
+    local STATUSCODE="${1}" REASON="${2}" REQTYPE="${3}" HEADERS="${4}"
+
+    # This hook is called when an HTTP request fails (e.g., when the ACME
+    # server is busy, returns an error, etc). It will be called upon any
+    # response code that does not start with '2'. Useful to alert admins
+    # about problems with requests.
+    #
+    # Parameters:
+    # - STATUSCODE
+    #   The HTML status code that originated the error.
+    # - REASON
+    #   The specified reason for the error.
+    # - REQTYPE
+    #   The kind of request that was made (GET, POST...)
+
+    # Simple example: Send mail to root
+    # printf "Subject: HTTP request failed failed!\n\nA http request failed with status ${STATUSCODE}!" | sendmail root
+}
+
+generate_csr() {
+    local DOMAIN="${1}" CERTDIR="${2}" ALTNAMES="${3}"
+
+    # This hook is called before any certificate signing operation takes place.
+    # It can be used to generate or fetch a certificate signing request with external
+    # tools.
+    # The output should be just the cerificate signing request formatted as PEM.
+    #
+    # Parameters:
+    # - DOMAIN
+    #   The primary domain as specified in domains.txt. This does not need to
+    #   match with the domains in the CSR, it's basically just the directory name.
+    # - CERTDIR
+    #   Certificate output directory for this particular certificate. Can be used
+    #   for storing additional files.
+    # - ALTNAMES
+    #   All domain names for the current certificate as specified in domains.txt.
+    #   Again, this doesn't need to match with the CSR, it's just there for convenience.
+
+    # Simple example: Look for pre-generated CSRs
+    # if [ -e "${CERTDIR}/pre-generated.csr" ]; then
+    #   cat "${CERTDIR}/pre-generated.csr"
+    # fi
+}
+
+startup_hook() {
+  # This hook is called before the cron command to do some initial tasks
+  # (e.g. starting a webserver).
+
+  :
+}
+
+exit_hook() {
+  # This hook is called at the end of the cron command and can be used to
+  # do some final (cleanup or other) tasks.
+
+  :
+}
+
+HANDLER="$1"; shift
+if [[ "${HANDLER}" =~ ^(deploy_challenge|clean_challenge|deploy_cert|unchanged_cert|invalid_challenge|request_failure|generate_csr|startup_hook|exit_hook)$ ]]; then
+  "$HANDLER" "$@"
+fi


### PR DESCRIPTION
With dehydrated v0.5, the "Run weekly cron script for direct certificate updates" task fail with the following error : 
```
/etc/dehydrated/hook.sh: ligne 29: startup_hook : command not found
```
They completely change the hook.sh file and add actions, at least "startup_hook".
I just use the new hook file and recopy your action in deploy_cert function.

Best way to achieve that would be to copy hook.sh from source and change deploy_cert function with Ansible (like you do for config file), but it's not easy.