### PR TITLE
Several improvements

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -41,6 +41,8 @@ dehydrated_configdir: /etc/dehydrated
 dehydrated_privatekeyrenew: yes
 # Option to add CSR-flag indicating OCSP stapling to be mandatory
 dehydrated_ocsp_must_staple: no
+# The type of key we should generate, one of 'rsa', 'prime256v1' or 'secp384r1'
+dehydrated_key_algo: rsa
 
 
 # The acme api to call, for tests use staging api

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -55,3 +55,14 @@ dehydrated_repourl: https://github.com/lukas2511/dehydrated.git
 # use here only versions you have reviewed by your self, dehydrated is
 # working with your secret key, so be carefull!
 dehydrated_commit: 116386486b3749e4c5e1b4da35904f30f8b2749b
+
+# Packages that need to be installed in order for dehydrated to function.
+# Change this when the ones in the target OS are named differently
+dehydrated_packages:
+  - bash
+  - curl
+  - git
+  - grep
+  - mktemp
+  - openssl
+  - sed

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -21,6 +21,8 @@ dehydrated_run_cron_on_every_ansible_run: true
 # See README.md for details.
 dehydrated_challengesdir: /var/www/dehydrated/
 
+# Use systemd timer instead of cron
+dehydrated_systemd_timer_instead_of_cron: false
 
 
 # unusual variables, normaly you don't need change any of them.

--- a/tasks/configure.yml
+++ b/tasks/configure.yml
@@ -71,3 +71,9 @@
     dest: "{{ dehydrated_configdir }}/config"
     regexp: "^#?CA"
     line: "CA=\"{{ dehydrated_acme_api }}\""
+
+- name: Set the key type to create
+  lineinfile:
+    dest: "{{ dehydrated_configdir }}/config"
+    regexp: "^#?KEY_ALGO"
+    line: "KEY_ALGO=\"{{ dehydrated_key_algo }}\""

--- a/tasks/cron_with_deploy_scripts.yml
+++ b/tasks/cron_with_deploy_scripts.yml
@@ -32,17 +32,51 @@
     mode: 0700
 
 
-- name: Add cron script for regularly renewals
-  template:
-    src: cron_dehydrated.j2
-    dest: /etc/cron.weekly/dehydrated
-    mode: 0700
+- block:
+    - name: Add cron script for regularly renewals
+      template:
+        src: cron_dehydrated.j2
+        dest: /etc/cron.weekly/dehydrated
+        mode: 0700
 
 
-- name: Run weekly cron script for direct certificate updates
-  shell: /etc/cron.weekly/dehydrated
-  register: cron_result
-  changed_when: "cron_result.stdout != ''"
-  tags:
-  - skip_ansible_lint
-  when: dehydrated_run_cron_on_every_ansible_run
+    - name: Run weekly cron script for direct certificate updates
+      shell: /etc/cron.weekly/dehydrated
+      register: cron_result
+      changed_when: "cron_result.stdout != ''"
+      tags:
+      - skip_ansible_lint
+      when: dehydrated_run_cron_on_every_ansible_run
+  when: not dehydrated_systemd_timer_instead_of_cron
+
+- block:
+    - name: Add script for regularly renewals
+      template:
+        src: cron_dehydrated.j2
+        dest: /usr/local/bin/dehydrated-weekly
+        mode: 0700
+
+    - name: Add systemd timer unit for dehydrated
+      template:
+        src: dehydrated-weekly.timer
+        dest: /etc/systemd/system/dehydrated-weekly.timer
+
+    - name: Add systemd service unit for dehydrated
+      template:
+        src: dehydrated-weekly.service
+        dest: /etc/systemd/system/dehydrated-weekly.service
+
+    - name: enable and start the timer unit
+      systemd:
+        name: dehydrated-weekly.timer
+        enabled: yes
+        state: started
+
+    - name: Run script for direct certificate updates
+      shell: /usr/local/bin/dehydrated-weekly
+      register: cron_result
+      changed_when: "cron_result.stdout != ''"
+      tags:
+      - skip_ansible_lint
+      when: dehydrated_run_cron_on_every_ansible_run
+  when: dehydrated_systemd_timer_instead_of_cron

--- a/tasks/packages.yml
+++ b/tasks/packages.yml
@@ -5,11 +5,4 @@
   package:
     name: "{{ item }}"
     state: present
-  with_items:
-  - bash
-  - curl
-  - git
-  - grep
-  - mktemp
-  - openssl
-  - sed
+  with_items: '{{ dehydrated_packages }}'

--- a/templates/dehydrated-weekly.service
+++ b/templates/dehydrated-weekly.service
@@ -1,0 +1,6 @@
+[Unit]
+Description=Updates certificates with Dehydrated
+
+[Service]
+Type=oneshot
+ExecStart=/usr/local/bin/dehydrated-weekly

--- a/templates/dehydrated-weekly.timer
+++ b/templates/dehydrated-weekly.timer
@@ -1,0 +1,10 @@
+[Unit]
+Description=Run dehydrated weekly
+
+[Timer]
+OnCalendar=weekly
+Persistent=true
+Unit=dehydrated-weekly.service
+
+[Install]
+WantedBy=timers.target


### PR DESCRIPTION
Hi,

While deploying dehydrated on my Arch Linux box, I found some issues with the role and I added some features.

#### Added a way to select certificate type
Dehydrated and letsencrypt allow for the use of ECDSA keys in certificates. Commit 7737080 adds support for setting the keytype in the `dehydrated_key_algo` variable, that defaults to `rsa`.

#### Added a way to specify the dependency packages
On Arch Linux, `mktemp` is shipped in the `coreutils` package, this made the installation step fail. The `dehydrated_packages` variable can be used to adjust this.

#### Added a systemd timer plus unit
Also on Arch Linux, cron is not installed by default and [systemd timers](https://www.freedesktop.org/software/systemd/man/systemd.timer.html) can be used. The last commit allows the user to set `dehydrated_systemd_timer_instead_of_cron` to do the weekly update-run. And this works:

```
▲ ~ systemctl list-timers dehydrated-weekly.timer
NEXT                         LEFT        LAST                         PASSED        UNIT                    ACTIVATES
Mon 2018-03-05 00:00:00 CET  5 days left Mon 2018-02-26 00:00:01 CET  1 day 13h ago dehydrated-weekly.timer dehydrated-weekly.service

▲ ~ systemctl status dehydrated-weekly.service
● dehydrated-weekly.service - Updates certificates with Dehydrated
   Loaded: loaded (/etc/systemd/system/dehydrated-weekly.service; static; vendor preset: disabled)
   Active: inactive (dead) since Mon 2018-02-26 00:00:03 CET; 1 day 13h ago
 Main PID: 29434 (code=exited, status=0/SUCCESS)

Feb 26 00:00:01 lychee systemd[1]: Starting Updates certificates with Dehydrated...
Feb 26 00:00:01 lychee su[29438]: (to dehydrated) root on none
Feb 26 00:00:01 lychee su[29438]: pam_unix(su:session): session opened for user dehydrated by (uid=0)
Feb 26 00:00:03 lychee su[29438]: pam_unix(su:session): session closed for user dehydrated
Feb 26 00:00:03 lychee su[29576]: (to dehydrated) root on none
Feb 26 00:00:03 lychee su[29576]: pam_unix(su:session): session opened for user dehydrated by (uid=0)
Feb 26 00:00:03 lychee su[29576]: pam_unix(su:session): session closed for user dehydrated
Feb 26 00:00:03 lychee systemd[1]: Started Updates certificates with Dehydrated.
```
And the log:

```
============= cron run 2018-02-26T00:00:01+01:00 start ==============
# INFO: Using main config file /etc/dehydrated/config
Processing test.lieter.nl
 + Checking domain name(s) of existing cert... unchanged.
 + Checking expire date of existing cert...
 + Valid till May 24 16:08:42 2018 GMT Certificate will not expire
(Longer than 30 days). Skipping renew!
============= dehydrated finished, start deploy certificates ==============
============= certificates deployed, start cleanup ==============
# INFO: Using main config file /etc/dehydrated/config
============= cron run 2018-02-26T00:00:03+01:00 end ==============
```